### PR TITLE
feat: add client app

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ You can get this program to run with the following steps steps:
 ./setup.sh # uses persistentVolumeClaims.yaml to create volume claims for MariaDB with the default storage class
 # if you want to use a custom storage class, do
 # ./setup.sh --custom-storage-class <storage-class-name>
+sconectl apply -f clientService.yaml # generates a custom FastAPI client container image
 sconectl apply -f service.yaml   # generates a custom FastAPI container image
 sconectl apply -f mesh.yaml  # generates/uploads the policies and helm charts
 ```

--- a/client-code/client.py
+++ b/client-code/client.py
@@ -1,0 +1,127 @@
+import os
+import time
+import json
+import random
+import string
+import requests
+import logging as log
+
+from base64 import b64encode
+
+
+def get_env_or_die(env_var):
+    log.info("Getting env var \"{}\"".format(env_var))
+    value = os.environ.get(env_var)
+    if value is None:
+        log.error("cannot get \"{}\" env var".format(env_var))
+        exit(1)
+    return value
+
+
+def create_document(nginx_addr, user, passwd, doc_id):
+    ''' Creates a document and returns the ID
+    returns ducument id (string)
+    '''
+    letters = string.ascii_letters
+    res = requests.post("https://{}/documents/create_document".format(nginx_addr),
+        auth=(user, passwd), data=json.dumps({
+            "record_id": doc_id,
+            "content": ''.join(random.choice(letters) for i in range(15))
+        }))
+    if res.status_code == 429:
+        log.info("ouch! rate limit caught us. Retrying in 70 seconds...")
+        time.sleep(70)
+        res = requests.post("https://{}/documents/create_document".format(nginx_addr),
+        auth=(user, passwd), data=json.dumps({
+            "record_id": doc_id,
+            "content": ''.join(random.choice(letters) for i in range(15))
+        }))
+    return res
+
+
+def read_document(nginx_addr, user, passwd, doc_id):
+    '''
+    param id (string): ID of the document to read
+    returns document content (string)
+    '''
+    res = requests.get("https://{}/documents/{}".format(nginx_addr, doc_id), auth=(user, passwd))
+    if res.status_code == 429:
+        log.info("ouch! rate limit caught us. Retrying in 70 seconds...")
+        time.sleep(70)
+        res = requests.get("https://{}/documents/{}".format(nginx_addr, doc_id), auth=(user, passwd))
+    return res
+
+
+def create_user(nginx_addr):
+    letters = string.ascii_letters
+    user = ''.join(random.choice(letters) for i in range(15))
+    passwd = ''.join(random.choice(letters) for i in range(15))
+
+    res = requests.get("https://{}/users/create_account".format(nginx_addr), auth=(user, passwd))
+    if res.status_code != 201:
+        log.error("could not create user account: status_code={} response:\n{}\n".format(res.status_code, res.content))
+        return None, None
+    return user, passwd
+    
+
+def do_work(nginx_addr):
+    doc_ids = []
+
+    number_of_docs_in_loop = 20
+    while_execution_number = 1
+    while True:
+        log.info("Creating user")
+        user, passwd = create_user(nginx_addr)
+        if user is None or passwd is None:
+            log.error("could not get auth creds")
+            continue
+        log.info("New user-passwd pair: user={} passwd={}".format(user, passwd))
+
+
+        log.info("Creating documents")
+        for i in range(number_of_docs_in_loop):
+            res = create_document(nginx_addr, user, passwd, str(i))
+            if res.status_code != 200:
+                log.error("got status code different from 200")
+                log.error(res.json())
+                time.sleep(2)
+                continue
+            log.info("response={}".format(res.json()))
+            time.sleep(2) 
+        time.sleep(10)
+
+        log.info("Reading written documents")
+        for i in range(number_of_docs_in_loop):
+            res = read_document(nginx_addr, user, passwd, str(i))
+            if res.status_code != 200:
+                continue
+            log.info("response={}".format(res.json()))
+            time.sleep(1)
+        time.sleep(10)
+
+        # empty doc_ids again
+        doc_ids = []
+
+        log.info("Finished execution number {}\n".format(while_execution_number))
+        while_execution_number += 1
+
+
+def wait_for_nginx(nginx_addr):
+    while True:
+        try:
+            requests.get("https://{}/documents/1".format(nginx_addr), timeout=5)
+            # if request went well, no matter which status code, NGINX is ready: get out of loop
+            break
+        except:
+            log.warning("NGINX not available yet. Will try again in 10 seconds...")
+            time.sleep(10)
+
+
+if __name__ == '__main__':
+    log.basicConfig(level=log.INFO)
+
+    nginx_addr = get_env_or_die("NGINX_ADDR")
+
+    wait_for_nginx(nginx_addr)
+
+    do_work(nginx_addr)

--- a/client-code/requirements.txt
+++ b/client-code/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/clientService.yaml
+++ b/clientService.yaml
@@ -1,0 +1,75 @@
+apiVersion: scone/5.8
+kind: genservice
+
+# Client service definition (genservice)
+
+# define environment variables
+#  - local ones are only visible for this service - typically, we use SCREAMING_SNAKE_CASE
+#    - local environment variables containing "SCONE" (like SCONE_HEAP) are used when signing the image
+#  - global ones must be defined in the Meshfile (or by some other services, we use snake_case)
+#
+# Value Types:
+#   - constant: defined and cannot change (e.g., "debug")
+#   - mesh time: defined when the services is connected with other services (e.g., {{database_host}})
+#   - run time: defined by SCONE CAS, e.g., $$SCONE::fastapi.crt$$
+
+environment:
+  local:
+    - name: SCONE_ALLOW_DLOPEN
+      value: 1
+    - name: SCONE_LOG  # automatically added to image
+      value: info
+    - name: SCONE_HEAP # automatically added to image
+      value: 600M
+    - name: PYTHONHOME
+      value: "/usr"
+    - name: REQUESTS_CA_BUNDLE # python requests will use this env var
+      value: "/etc/nginx_ca.crt"
+    - name: NGINX_ADDR
+      value: "{{nginx_server_name}}"
+  global: # must be defined in Meshfile!
+    - name: CLUSTER_DNS_IP # we need to know the cluster IP
+    - name: K8sNAMESPACE   # we need to know the Kubernetes namespace in which we run (for DNS service)
+
+#
+# We can make configuration parameters visible to applications via injected files
+#
+
+injection_files:
+  # todo: ensure this cert is available
+  - path: /etc/nginx_ca.crt
+    content: $$SCONE::NGINX_SERVER_CA_CERT.chain$$
+  # Network files
+  - path: /etc/resolv.conf
+    content: |
+      nameserver {{CLUSTER_DNS_IP}}
+      search {{K8sNAMESPACE}}.svc.cluster.local svc.cluster.local cluster.local
+      options ndots:5
+  - path: /etc/hosts
+    content: |
+      # Kubernetes-managed hosts file.
+      127.0.0.1   localhost
+      ::1 localhost ip6-localhost ip6-loopback
+      fe00::0     ip6-localnet
+      fe00::0     ip6-mcastprefix
+      fe00::1     ip6-allnodes
+      fe00::2     ip6-allrouters
+
+#
+# run-time secrets (handled by SCONE CAS)
+#
+
+secrets:
+  import:
+    - NGINX_SERVER_CA_CERT
+
+
+build:
+  name: fastapi-client-scone
+  kind: python
+  to: registry.scontain.com:5050/cicd/secure_document_app_client
+  copy:
+    - client-code/client.py
+  requirements: client-code/requirements.txt
+  pwd: /python
+  command: python3 client-code/client.py

--- a/mesh.yaml
+++ b/mesh.yaml
@@ -66,6 +66,8 @@ services:
     image: registry.scontain.com:5050/cicd/mariadb:latest
   - name: fastapi-scone
     image: registry.scontain.com:5050/cicd/secure_document_app
+  - name: client
+    image: registry.scontain.com:5050/cicd/secure_document_app_client
 
 helm_extra_values:
   mariadb-scone:

--- a/service.yaml
+++ b/service.yaml
@@ -16,7 +16,7 @@ environment:
     - name: SCONE_ALLOW_DLOPEN
       value: 1
     - name: SCONE_LOG  # automatically added to image
-      value: debug
+      value: info
     - name: SCONE_HEAP # automatically added to image
       value: 600M
     - name: DB_HOST
@@ -74,7 +74,7 @@ injection_files:
   - path: /etc/mariadb-client.key
     content: $$SCONE::MARIADB_CLIENT_CERT.key$$
   - path: /etc/memcached-ca.crt
-    content: $$SCONE::MEMCACHED_CA_CERT.chain$$ 
+    content: $$SCONE::MEMCACHED_CA_CERT.chain$$
   - path: /etc/memcached-client.crt
     content: $$SCONE::MEMCACHED_CLIENT_CERT.crt$$
   - path: /etc/memcached-client.key


### PR DESCRIPTION
Added a client app to showcase fastapi usage.

The apps shows document creation, retrieval, and also rate limiting. The log looks like the following:

```
INFO:root:Getting env var "NGINX_ADDR"
WARNING:root:NGINX not available yet. Will try again in 10 seconds...
WARNING:root:NGINX not available yet. Will try again in 10 seconds...
WARNING:root:NGINX not available yet. Will try again in 10 seconds...
WARNING:root:NGINX not available yet. Will try again in 10 seconds...
WARNING:root:NGINX not available yet. Will try again in 10 seconds...
WARNING:root:NGINX not available yet. Will try again in 10 seconds...
WARNING:root:NGINX not available yet. Will try again in 10 seconds...
INFO:root:Creating user
INFO:root:New user-passwd pair: user=CVnXWsPvGkSzvyz passwd=RlnhzRYItKXYCVE
INFO:root:Creating documents
INFO:root:response={'record_id': 0, 'content': 'FHOcmHkEsiKvyiv'}
INFO:root:response={'record_id': 1, 'content': 'BpTiLVraWnbsbBg'}
INFO:root:response={'record_id': 2, 'content': 'uPCnIhlotCtewGZ'}
INFO:root:response={'record_id': 3, 'content': 'SqdxBnJtTKMOzhz'}
INFO:root:response={'record_id': 4, 'content': 'hlWETkHWfBdQNAr'}
INFO:root:response={'record_id': 5, 'content': 'IpLnzWBFEtmPIov'}
INFO:root:response={'record_id': 6, 'content': 'FIFXZdJIxktozEv'}
INFO:root:response={'record_id': 7, 'content': 'aEJEcWCSbCYRUsd'}
INFO:root:response={'record_id': 8, 'content': 'yNtmQlbwLPelhSt'}
INFO:root:response={'record_id': 9, 'content': 'bKSdOTlwtYEsrVd'}
INFO:root:ouch! rate limit caught us. Retrying in 70 seconds...
INFO:root:response={'record_id': 10, 'content': 'xtbmvtMyKsXDDWl'}
INFO:root:response={'record_id': 11, 'content': 'TSBrhlOkWLQOiPA'}
INFO:root:response={'record_id': 12, 'content': 'OaqAjUwVEdwEjBd'}
INFO:root:response={'record_id': 13, 'content': 'JqHeAdyEkcgxyZa'}
INFO:root:response={'record_id': 14, 'content': 'HCjADoPRdSjaTbk'}
INFO:root:response={'record_id': 15, 'content': 'sdRxcNhwNUcebLR'}
INFO:root:response={'record_id': 16, 'content': 'HrxoEVwYAIcWHKK'}
INFO:root:response={'record_id': 17, 'content': 'ghmzlZRDDOTViWH'}
INFO:root:response={'record_id': 18, 'content': 'EMlHAGdtBhJXTJl'}
INFO:root:response={'record_id': 19, 'content': 'RgZAWscsNYkvATr'}
INFO:root:Reading written documents
INFO:root:response={'record_id': 0, 'content': 'FHOcmHkEsiKvyiv', 'owner': 'CVnXWsPvGkSzvyz'}
INFO:root:ouch! rate limit caught us. Retrying in 70 seconds...
```